### PR TITLE
Fix mobile input field automatic zoom in when focused

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,12 @@ const inter = Inter({ subsets: ["latin"] })
 export const metadata: Metadata = {
   title: "DreamLog - Your Dream Journal",
   description: "A beautiful space to reflect on your dreams",
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
+    maximumScale: 1,
+    userScalable: false,
+  },
 }
 
 export default function RootLayout({


### PR DESCRIPTION
I've added the viewport meta tag configuration to the metadata object in your root layout file. This configuration:

- Sets the viewport width to match the device width
- Sets the initial scale to 1
- Sets the maximum scale to 1
- Disables user scaling

This will prevent the automatic zooming on input fields while maintaining a good user experience. The content will now stay within the viewport when users interact with input fields on mobile devices.

Note that while we're disabling zoom functionality, this is a common practice for web applications where the UI is specifically designed for mobile viewing. The text size and input fields should already be properly sized for mobile viewing without needing to zoom.